### PR TITLE
Preload everything before first request

### DIFF
--- a/backend/start.py
+++ b/backend/start.py
@@ -6,6 +6,7 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
+from backend.dependencies import get_evidence_sentences_and_frequencies
 from build_network import SignificanceRow          # Required by pickle
 from .api import api_router
 from .viz_api import api_router as viz_api_router
@@ -14,6 +15,9 @@ from backend.cli_parser import args
 logger = logging.getLogger("frailty_viz_main")
 
 logger.addHandler(logging.StreamHandler())
+
+# Load the data beforehand. This is necessary because React sometimes refreshes component multiple times when loading for first time. Which runs this function multiple times perallally in different threads (and LRU does not become effective)
+get_evidence_sentences_and_frequencies()
 
 app = FastAPI(title="Frailty Visualization REST API")
 


### PR DESCRIPTION
I noticed that, when we start the backend, nothing is loaded in memory and only the endpoints are being served. This results in a penalty for the first request made from the front end. Moreover, sometimes React loads/refreshes components twice which forces the backend to load the data twice in the memory parallelly (without using the LRU). 

For these reasons, I thought that we should load all data before serving API in backend. If this is not proper way to do things, feel free the close this PR without merging.